### PR TITLE
Fixing #6 UseRazorComponentsRuntimeCompilation ReadAllFiles NRE

### DIFF
--- a/src/RazorComponentsPreview/Razor/RuntimeComponentsGenerator.cs
+++ b/src/RazorComponentsPreview/Razor/RuntimeComponentsGenerator.cs
@@ -84,11 +84,14 @@ namespace RazorComponentsPreview
             files.Insert(0, razorImportsFile);
 
             //hack for to get dependencies from Test
-            var item = files.SingleOrDefault(item => item.FilePath.Contains("App.razor"));
-            var fixedAPPcontent = item.Content.Replace("@typeof(", "@typeof(Test.").Replace("Program", "Counter"); //Todo change name "Counter" to dynamic type from Test Assemebly
-            files.Remove(item);
-            files.Add((item.FilePath, fixedAPPcontent));
+            var appRazorItem = files.SingleOrDefault(item => item.FilePath.Contains("App.razor"));
 
+            if (appRazorItem != default)
+            {
+                var fixedAPPcontent = appRazorItem.Content.Replace("@typeof(", "@typeof(Test.").Replace("Program", "Counter"); //Todo change name "Counter" to dynamic type from Test Assemebly
+                files.Remove(appRazorItem);
+                files.Add((appRazorItem.FilePath, fixedAPPcontent));
+            }
 
             return files;
         }


### PR DESCRIPTION
Fixes NRE when App.Razor file is not found. 

Not quiet sure why it is not found or why there is a hard dependency on it in the code.

From the looks of it, it looks like it replaces some test types, so seems to be safe to put behind a null check